### PR TITLE
Fix XOSI wording

### DIFF
--- a/content/0.guide/3.gathering-files/3.acpi.md
+++ b/content/0.guide/3.gathering-files/3.acpi.md
@@ -112,7 +112,7 @@ AMD laptops should choose, in addition
 - `PNLF`
 - `XOSI`
 
-  Choose default (`A` key)
+  Choose option 19 (for AMD systems)
 ::
 
 Here's how the `Results` folder would look like after we're done


### PR DESCRIPTION
Changes 
XOSI:
Choose default ('B' key)
to XOSI:
Choose option 19 (for AMD systems)